### PR TITLE
- use `/usr/bin/env` to locate bash for better compatbility

### DIFF
--- a/script-dialog.sh
+++ b/script-dialog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #multi-ui scripting
 # shellcheck disable=SC2046
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # shellcheck source=./script-dialog.sh


### PR DESCRIPTION
Bash can be installed on a system and available in the system path, but not reside in `/bin`, this was often the case on old Solaris boxes, but it continues to be the case on NixOS, where my current bash resides at `/nix/store/x88ivkf7rmrhd5x3cvyv5vh3zqqdnhsk-bash-interactive-5.2-p15/bin/bash`

This fix asks `env` to resolve the location of the bash interpreter for running the scripts.